### PR TITLE
Support for (more) games purchased through Steam

### DIFF
--- a/src/backend.py
+++ b/src/backend.py
@@ -4,6 +4,14 @@ import logging as log
 class ParadoxClient:
     def __init__(self, http_client):
         self.http_client = http_client
+        self._skus = {}
+
+    async def get_skus(self):
+        if not self._skus:
+            skus = await self.http_client.do_request('GET', 'https://accounts.paradoxplaza.com/api/skus',
+                                                     headers={'content-type': 'application/json'})
+            self._skus = await skus.json()
+        return self._skus
 
     async def get_account_id(self):
         data = {'Authorization': f'{{"session":{{"token":"{self.http_client.token}"}}}}',
@@ -15,13 +23,11 @@ class ParadoxClient:
     async def get_owned_games(self):
         data = {'Authorization': f'{{"session":{{"token":"{self.http_client.token}"}}}}',
                 'content-type': 'application/json'}
-        skus = await self.http_client.do_request('GET', 'https://accounts.paradoxplaza.com/api/skus',
-                                                 headers={'content-type': 'application/json'})
         response = await self.http_client.do_request('GET', 'https://api.paradox-interactive.com/inventory/products',
                                                      headers=data)
 
-        skus = await skus.json()
         response = await response.json()
+        skus = await self.get_skus()
 
         owned_products = []
         if 'products' in response:

--- a/src/backend.py
+++ b/src/backend.py
@@ -35,8 +35,9 @@ class ParadoxClient:
                 for platform in platforms:
                     for game in platforms[platform]:
                         log.info(game)
-                        if game['sku'] and game['title'] and game['product_type'] and game['sku'] in skus:
-                            if 'paradoxLauncher' in skus[game['sku']]['platform']:
+                        if game['sku'] and game['title'] and game['product_type']:
+                            if (game['sku'] in skus and 'paradoxLauncher' in skus[game['sku']]['platform']) \
+                                    or "paradox builds" in game['platforms']:
                                 owned_products.append({'sku': game['sku'],
                                                        'title': game['title'],
                                                        'type': game['product_type']})

--- a/src/backend.py
+++ b/src/backend.py
@@ -15,9 +15,12 @@ class ParadoxClient:
     async def get_owned_games(self):
         data = {'Authorization': f'{{"session":{{"token":"{self.http_client.token}"}}}}',
                 'content-type': 'application/json'}
+        skus = await self.http_client.do_request('GET', 'https://accounts.paradoxplaza.com/api/skus',
+                                                 headers={'content-type': 'application/json'})
         response = await self.http_client.do_request('GET', 'https://api.paradox-interactive.com/inventory/products',
                                                      headers=data)
 
+        skus = await skus.json()
         response = await response.json()
 
         owned_products = []
@@ -26,9 +29,10 @@ class ParadoxClient:
                 for platform in platforms:
                     for game in platforms[platform]:
                         log.info(game)
-                        if game['sku'] and game['title'] and game['product_type'] and "paradox builds" in game['platforms']:
-                            owned_products.append({'sku': game['sku'],
-                                                   'title': game['title'],
-                                                   'type': game['product_type']})
+                        if game['sku'] and game['title'] and game['product_type'] and game['sku'] in skus:
+                            if 'paradoxLauncher' in skus[game['sku']]['platform']:
+                                owned_products.append({'sku': game['sku'],
+                                                       'title': game['title'],
+                                                       'type': game['product_type']})
         log.info(owned_products)
         return owned_products


### PR DESCRIPTION
Games purchased with a linked Steam account wouldn't show up in Galaxy (see #4). This should allow any games that work through the Paradox launcher to show up through Galaxy as well. Though I have a pretty small selections of games for testing, so the code definitely needs some review!